### PR TITLE
Support terraform 0.12 syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.2.0] - 2020-02-03
+- Support terraform 0.12 syntax
+
 ## [1.1.0] - 2019-10-03
 
 - renew existing certificates before deleting the old one
@@ -25,7 +28,8 @@ All notable changes to this project will be documented in this file.
 
 - Initial release
 
-[Unreleased]: https://github.com/nephosolutions/terraform-google-gcp-project/compare/v1.1.0...HEAD
+[Unreleased]: https://github.com/nephosolutions/terraform-google-gcp-project/compare/v1.2.0...HEAD
+[1.2.0]: https://github.com/nephosolutions/terraform-google-gcp-project/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/nephosolutions/terraform-google-gcp-project/compare/v1.0.2...v1.1.0
 [1.0.2]: https://github.com/nephosolutions/terraform-google-gcp-project/compare/v1.0.1...v1.0.2
 [1.0.1]: https://github.com/nephosolutions/terraform-google-gcp-project/compare/v1.0.0...v1.0.1

--- a/main.tf
+++ b/main.tf
@@ -13,13 +13,13 @@
 # limitations under the License.
 
 module "acme_account" {
-  source = "modules/account"
+  source = "./modules/account"
 
   email_address = "${var.email_address}"
 }
 
 module "acme_certificate" {
-  source = "modules/certificate"
+  source = "./modules/certificate"
 
   acme_account_id          = "${module.acme_account.id}"
   acme_account_private_key = "${module.acme_account.private_key}"


### PR DESCRIPTION
Terraform 0.12 requires any relative path to start with `./`, if it doesn't start with `./`, you get the following error when running `terraform init`:
```
Error: Module not found

The module address "modules/account" could not be resolved.

If you intended this as a path relative to the current module, use
"./modules/account" instead. The "./" prefix indicates that the address is a
relative filesystem path.


Error: Module not found

The module address "modules/certificate" could not be resolved.

If you intended this as a path relative to the current module, use
"./modules/certificate" instead. The "./" prefix indicates that the address is
a relative filesystem path.

```